### PR TITLE
Ignore undefined options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "airtable-lite",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^26.0.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "airtable-lite",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Light weight type safe Airtable API client",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -176,6 +176,20 @@ describe("Airtable", () => {
             expect(offset).toBeUndefined();
         });
 
+        it("should handle undefined correctly", async () => {
+            fetchMock.mockResponseOnce(async (req) => {
+                const url = new URL(req.url);
+                expect(Array.from(url.searchParams.keys())).toHaveLength(0);
+                return JSON.stringify({ records: [] });
+            });
+            const client = new Airtable<Example>("", "", "Examples");
+            const { records, offset } = await client.select({
+                maxRecords: undefined,
+            });
+            expect(records).toHaveLength(0);
+            expect(offset).toBeUndefined();
+        });
+
         it("should infer types correctly", async () => {
             const client = new Airtable<Example>("", "", "Examples");
             const records: ReadonlyArray<AirtableRecord<Example>> = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,9 @@ export class Airtable<T> implements AirtableClient<T> {
         const url = this._createURL();
         if (options !== undefined) {
             for (const [key, value] of Object.entries(options)) {
+                if (value === undefined) {
+                    continue;
+                }
                 switch (key) {
                     case "fields": {
                         for (const field of value as ReadonlyArray<string>) {


### PR DESCRIPTION
Instead of crashing, silently filter them out since undefined is allowed.